### PR TITLE
Refactor: Use StructureMatcher defaults and fix batch reconstruction

### DIFF
--- a/configs/vae_module/vae_module.yaml
+++ b/configs/vae_module/vae_module.yaml
@@ -26,9 +26,6 @@ atom_type_predict: True
 
 structure_matcher:
   _target_: pymatgen.analysis.structure_matcher.StructureMatcher
-  ltol: 0.3
-  stol: 0.5
-  angle_tol: 10
 
 optimizer:
   _target_: torch.optim.AdamW

--- a/src/vae_module/vae_module.py
+++ b/src/vae_module/vae_module.py
@@ -11,7 +11,7 @@ from pymatgen.core import Structure
 
 from src.data.data_augmentation import apply_augmentation, apply_noise
 from src.data.dataset_util import lattice_params_to_matrix_torch
-from src.data.schema import CrystalBatch
+from src.data.schema import CrystalBatch, create_empty_batch
 from src.utils.timeout import timeout
 
 
@@ -235,7 +235,7 @@ class VAEModule(LightningModule):
 
     def reconstruct(self, decoder_out: dict, batch: CrystalBatch):
         # Reconstructed batch
-        batch_recon = batch.clone()
+        batch_recon = create_empty_batch(batch.num_atoms, self.device)
         _atom_types = (
             decoder_out["atom_types"].argmax(dim=-1)
             if self.hparams.atom_type_predict


### PR DESCRIPTION
## Summary
- Remove custom tolerance parameters from StructureMatcher configuration, defaulting to pymatgen's standard values
- Fix VAE batch reconstruction by using `create_empty_batch()` instead of `batch.clone()` for proper initialization

## Changes
- **configs/vae_module/vae_module.yaml**: Removed `ltol`, `stol`, and `angle_tol` parameters, relying on pymatgen defaults
- **src/vae_module/vae_module.py**: Updated `reconstruct()` method to use `create_empty_batch()` for cleaner batch initialization

## Test plan
- [x] Run baseline VAE tests: `pytest tests/baseline/test_vae_module.py -v -m baseline`
- [x] Verify pre-commit hooks pass
- [x] Check reconstruction accuracy is maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)